### PR TITLE
Feature/use output button instead of switch

### DIFF
--- a/components/sc_cover/cover.py
+++ b/components/sc_cover/cover.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
+from esphome.components import binary_sensor, button, cover
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, cover, switch
 from esphome.const import (
     CONF_CLOSE_DURATION,
     CONF_CLOSE_ENDSTOP,
@@ -9,8 +9,8 @@ from esphome.const import (
     CONF_OPEN_ENDSTOP,
 )
 
-CONF_DOOR_SWITCH = "door_switch"
-CONF_SWITCH_INTERVAL = "switch_interval"
+CONF_DOOR_ACTIVATE_BUTTON = "door_activate_button"
+CONF_BUTTON_PRESS_INTERVAL = "button_press_interval"
 
 sc_cover_ns = cg.esphome_ns.namespace("sc_cover")
 SingleControlCover = sc_cover_ns.class_("SingleControlCover", cover.Cover, cg.Component)
@@ -19,8 +19,10 @@ CONFIG_SCHEMA = (
     cover.cover_schema(SingleControlCover)
     .extend(
         {
-            cv.Required(CONF_DOOR_SWITCH): cv.use_id(switch.Switch),
-            cv.Required(CONF_SWITCH_INTERVAL): cv.positive_time_period_milliseconds,
+            cv.Required(CONF_DOOR_ACTIVATE_BUTTON): cv.use_id(button.Button),
+            cv.Required(
+                CONF_BUTTON_PRESS_INTERVAL
+            ): cv.positive_time_period_milliseconds,
             cv.Required(CONF_OPEN_ENDSTOP): cv.use_id(binary_sensor.BinarySensor),
             cv.Required(CONF_OPEN_DURATION): cv.positive_time_period_milliseconds,
             cv.Required(CONF_CLOSE_ENDSTOP): cv.use_id(binary_sensor.BinarySensor),
@@ -30,14 +32,15 @@ CONFIG_SCHEMA = (
     .extend(cv.COMPONENT_SCHEMA)
 )
 
+
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await cover.register_cover(var, config)
 
-    bin = await cg.get_variable(config[CONF_DOOR_SWITCH])
-    cg.add(var.set_door_switch(bin))
-    cg.add(var.set_switch_interval(config[CONF_SWITCH_INTERVAL]))
+    bin = await cg.get_variable(config[CONF_DOOR_ACTIVATE_BUTTON])
+    cg.add(var.set_door_activate_button(bin))
+    cg.add(var.set_button_press_interval(config[CONF_BUTTON_PRESS_INTERVAL]))
 
     bin = await cg.get_variable(config[CONF_OPEN_ENDSTOP])
     cg.add(var.set_open_endstop(bin))

--- a/components/sc_cover/sc_cover.h
+++ b/components/sc_cover/sc_cover.h
@@ -3,8 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/cover/cover.h"
-#include "esphome/components/output/button/output_button.h"
 
 namespace esphome {
 namespace sc_cover {
@@ -31,7 +31,7 @@ class SingleControlCover : public cover::Cover, public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  void set_door_activate_button(output::OutputButton *door_activate_button) { this->door_activate_button_ = door_activate_button; }
+  void set_door_activate_button(button::Button *door_activate_button) { this->door_activate_button_ = door_activate_button; }
   void set_button_press_interval(uint32_t button_press_interval) { this->button_press_interval_ = button_press_interval; }
   void set_open_endstop(binary_sensor::BinarySensor *open_endstop) { this->open_endstop_ = open_endstop; }
   void set_close_endstop(binary_sensor::BinarySensor *close_endstop) { this->close_endstop_ = close_endstop; }
@@ -54,7 +54,7 @@ class SingleControlCover : public cover::Cover, public Component {
   void open_endstop_callback_(bool state);
   void close_endstop_callback_(bool state);
 
-  output::OutputButton *door_activate_button_;
+  button::Button *door_activate_button_;
   binary_sensor::BinarySensor *open_endstop_;
   binary_sensor::BinarySensor *close_endstop_;
   bool toggle_{false};

--- a/components/sc_cover/sc_cover.h
+++ b/components/sc_cover/sc_cover.h
@@ -4,7 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/cover/cover.h"
-#include "esphome/components/switch/switch.h"
+#include "esphome/components/output/button/output_button.h"
 
 namespace esphome {
 namespace sc_cover {
@@ -31,8 +31,8 @@ class SingleControlCover : public cover::Cover, public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  void set_door_switch(switch_::Switch *door_switch) { this->door_switch_ = door_switch; }
-  void set_switch_interval(uint32_t switch_interval) { this->switch_interval_ = switch_interval; }
+  void set_door_activate_button(output::OutputButton *door_activate_button) { this->door_activate_button_ = door_activate_button; }
+  void set_button_press_interval(uint32_t button_press_interval) { this->button_press_interval_ = button_press_interval; }
   void set_open_endstop(binary_sensor::BinarySensor *open_endstop) { this->open_endstop_ = open_endstop; }
   void set_close_endstop(binary_sensor::BinarySensor *close_endstop) { this->close_endstop_ = close_endstop; }
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
@@ -49,16 +49,16 @@ class SingleControlCover : public cover::Cover, public Component {
 
   void recompute_position_(const uint32_t now);
 
-  bool activate_switch_();
+  bool activate_door_();
 
   void open_endstop_callback_(bool state);
   void close_endstop_callback_(bool state);
 
-  switch_::Switch *door_switch_;
+  output::OutputButton *door_activate_button_;
   binary_sensor::BinarySensor *open_endstop_;
   binary_sensor::BinarySensor *close_endstop_;
   bool toggle_{false};
-  uint32_t switch_interval_;
+  uint32_t button_press_interval_;
   uint32_t open_duration_;
   uint32_t close_duration_;
 

--- a/example.yaml
+++ b/example.yaml
@@ -17,7 +17,7 @@ substitutions:
   # switch config
   cover_switch_pin: GPIO17 # gpio pin that triggers the door opening/closing/stop
   active_switch_duration: 100ms # amount of time relay is closed
-  switch_interval: 1500ms # milliseconds
+  switch_interval: 1500ms # time between switch activations
 
   # endstop config
   open_endstop_pin: GPIO18 # gpio pin for open endstop sensor
@@ -94,25 +94,28 @@ binary_sensor:
       then:
         - cover.toggle: $cover_id
 
-switch:
+output:
   - platform: gpio
     pin: $cover_switch_pin
-    name: "Cover Switch"
     id: cover_switch
+
+button:
+  - platform: output
+    name: "Cover Button"
+    id: cover_button
+    output: cover_switch
+    duration: $active_switch_duration
     internal: true
-    restore_mode: ALWAYS_OFF
-    on_turn_on:
-      - delay: $active_switch_duration
-      - switch.turn_off: cover_switch
+
 
 cover:
   - platform: sc_cover
     name: $cover_id
     id: $cover_id
     device_class: $cover_device_class
-    door_switch: cover_switch
+    door_activate_button: cover_button
     open_endstop: open_endstop
     close_endstop: close_endstop
-    switch_interval: $switch_interval
+    button_press_interval: $switch_interval
     open_duration: $open_duration
     close_duration: $close_duration


### PR DESCRIPTION
Use an output button isntead of a switch component to activate the door.