### PR TITLE
Add a delay to the setup

### DIFF
--- a/components/sc_cover/cover.py
+++ b/components/sc_cover/cover.py
@@ -11,6 +11,7 @@ from esphome.const import (
 
 CONF_DOOR_ACTIVATE_BUTTON = "door_activate_button"
 CONF_BUTTON_PRESS_INTERVAL = "button_press_interval"
+CONF_SETUP_DELAY = "setup_delay"
 
 sc_cover_ns = cg.esphome_ns.namespace("sc_cover")
 SingleControlCover = sc_cover_ns.class_("SingleControlCover", cover.Cover, cg.Component)
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_OPEN_DURATION): cv.positive_time_period_milliseconds,
             cv.Required(CONF_CLOSE_ENDSTOP): cv.use_id(binary_sensor.BinarySensor),
             cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_SETUP_DELAY): cv.positive_time_period_milliseconds,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -37,6 +39,10 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await cover.register_cover(var, config)
+
+    setup_delay = config.get(CONF_SETUP_DELAY)
+    if setup_delay:
+        cg.add(var.set_setup_delay(setup_delay))
 
     bin = await cg.get_variable(config[CONF_DOOR_ACTIVATE_BUTTON])
     cg.add(var.set_door_activate_button(bin))

--- a/components/sc_cover/sc_cover.cpp
+++ b/components/sc_cover/sc_cover.cpp
@@ -23,6 +23,7 @@ CoverTraits SingleControlCover::get_traits() {
 void SingleControlCover::dump_config() {
   LOG_COVER("", "SingleControl Cover", this);
   LOG_BUTTON(" ", "Door Switch", this->door_activate_button_);
+  ESP_LOGCONFIG(TAG, " Setup delay: %.1fs", this->setup_delay_ /1e3f);
   ESP_LOGCONFIG(TAG, " Switch Interval:  %.1fs", this->button_press_interval_ / 1e3f);
   LOG_BINARY_SENSOR("  ", "Open Endstop", this->open_endstop_);
   ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration_ / 1e3f);
@@ -36,6 +37,14 @@ void SingleControlCover::setup() {
   this->open_endstop_->add_on_state_callback([this](bool state) { this->open_endstop_callback_(state); });
   this->close_endstop_->add_on_state_callback([this](bool state) { this->close_endstop_callback_(state); });
 
+  this->do_setup_();
+
+  if (this->setup_delay_ > 0) {
+    this->set_timeout(this->setup_delay_, [this] { this->do_setup_(); });
+  }
+}
+
+void SingleControlCover::do_setup_() {
   if (this->is_open_()) {
     // door is open
     this->position = COVER_OPEN;

--- a/components/sc_cover/sc_cover.h
+++ b/components/sc_cover/sc_cover.h
@@ -33,6 +33,7 @@ class SingleControlCover : public cover::Cover, public Component {
 
   void set_door_activate_button(button::Button *door_activate_button) { this->door_activate_button_ = door_activate_button; }
   void set_button_press_interval(uint32_t button_press_interval) { this->button_press_interval_ = button_press_interval; }
+  void set_setup_delay(uint32_t setup_delay) { this->setup_delay_ = setup_delay; }
   void set_open_endstop(binary_sensor::BinarySensor *open_endstop) { this->open_endstop_ = open_endstop; }
   void set_close_endstop(binary_sensor::BinarySensor *close_endstop) { this->close_endstop_ = close_endstop; }
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
@@ -41,6 +42,7 @@ class SingleControlCover : public cover::Cover, public Component {
   cover::CoverTraits get_traits() override;
 
  protected:
+  void do_setup_();
   void control(const cover::CoverCall &call) override;
   bool is_open_() const { return this->open_endstop_->state; }
   bool is_closed_() const { return this->close_endstop_->state; }
@@ -61,6 +63,7 @@ class SingleControlCover : public cover::Cover, public Component {
   uint32_t button_press_interval_;
   uint32_t open_duration_;
   uint32_t close_duration_;
+  uint32_t setup_delay_{0};
 
   uint32_t last_activation_time_{0};
   uint32_t last_recompute_time_{0};

--- a/example.yaml
+++ b/example.yaml
@@ -24,6 +24,12 @@ substitutions:
   close_endstop_pin: GPIO19 # gpio pin for close endstop sensor
   debounce_time: 100ms # debounce time for open/close endstops
 
+  # setup config
+  # If your endstops take a while to configure (eg with debounce)
+  # Then you can set this.  If you do, it should be longer than
+  # the debouce time, plus around 50ms.
+  setup_delay: 200ms
+
 esphome:
   name: $device_name
 
@@ -114,6 +120,7 @@ cover:
     id: $cover_id
     device_class: $cover_device_class
     door_activate_button: cover_button
+    setup_delay: $setup_delay
     open_endstop: open_endstop
     close_endstop: close_endstop
     button_press_interval: $switch_interval


### PR DESCRIPTION
I also encountered #15 and after reading through the issue I thought to myself "What if the debounce is the problem?" so I made this patch to add a delay during setup so that we pick up the state *after* the debounce is done.

I'm not sure if this is the "right" thing to do, but it does seem to solve the problem for me.